### PR TITLE
fixed example code with ParseException and updated result

### DIFF
--- a/src/pages/blog/pyparsing-trees.mdx
+++ b/src/pages/blog/pyparsing-trees.mdx
@@ -47,11 +47,11 @@ Pyparsing supports recursive grammars using a grammar component called `Forward`
 grammar = pyparsing.Forward()
 grammar << pyparsing.Suppress("(") + pyparsing.Word("0123456789") + pyparsing.ZeroOrMore(grammar) + pyparsing.Suppress(")")
 
-query = "(1 (2 (3)) (4 (5 (6) (7) (8)))"
+query = "(1 (2 (3)) (4 (5 (6) (7) (8))))"
 ```
 ```
 >>> print(grammar.parseString(query))
-['5', '6', '7', '9', '9', '5', '6', '7', '8', '9', '7', '8', '9']
+['1', '2', '3', '4', '5', '6', '7', '8']
 ```
 
 This parses the grammar, but we still don't have the tree structure.


### PR DESCRIPTION
There was one ")" missing, producing an ParseException. I changed it to the same tree you used at the end of the article.
Furthermore, the example output did not match to the input. I changed the output to the actual output of the (corrected) input.
I guess in a former version of the article you experimented with a more complex tree, but changed it to a simpler one?

Anyway, thanks for the article!
For me, it has just the correct balance between not being too simple and not being too advanced. :)