### PR TITLE
was this maybe a pyparsing api change?

### DIFF
--- a/src/pages/blog/pyparsing-trees.mdx
+++ b/src/pages/blog/pyparsing-trees.mdx
@@ -132,8 +132,10 @@ def pprint(node, tab=""):
       pprint(child, tab + "    ")
 ```
 
+The result we are looking for is in the first item ([0]) of the parsing result.
+
 ```
->>> pprint(grammar.parseString("(1 (2 (3)) (4 (5 (6) (7) (8))))"))
+>>> pprint(grammar.parseString("(1 (2 (3)) (4 (5 (6) (7) (8))))")[0])
 ┗━ 1
     ┗━ 2
         ┗━ 3


### PR DESCRIPTION
Okay, this is a weird one, I don't really understand yet...
But to get your code again in a working state, it seems like it is necessary to access the first [0] element of the parsing result.
Did maybe the pyparsing api change?
Is this something wrong at my side?
For reference, see your full working code here:
https://gist.github.com/UweKrause/98b6bc24294ff0f7b09199d5fd000f32